### PR TITLE
fjernes key ved value == null

### DIFF
--- a/src/main/kotlin/no/nav/eessi/pensjon/journalforing/services/journalpost/JournalpostService.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/journalforing/services/journalpost/JournalpostService.kt
@@ -89,7 +89,7 @@ class JournalpostService(private val journalpostOidcRestTemplate: RestTemplate) 
         try {
             logger.info("Kaller Journalpost for å generere en journalpost")
 
-            val requestBody = byggJournalPostRequest(sedHendelse= sedHendelse, pdfBody = pdfBody)
+            val requestBody = byggJournalPostRequest(sedHendelse= sedHendelse, pdfBody = pdfBody).toString()
             genererJournalpostModelVellykkede.increment()
 
 

--- a/src/test/kotlin/no/nav/eessi/pensjon/journalforing/services/journalpost/JournalpostServiceTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/journalforing/services/journalpost/JournalpostServiceTest.kt
@@ -60,7 +60,7 @@ class JournalpostServiceTest {
                 .`when`(mockrestTemplate).exchange(
                         eq("/journalpost?forsoekFerdigstill=false"),
                         eq(HttpMethod.POST),
-                        eq(HttpEntity(journalpostService.byggJournalPostRequest(sedHendelse = sedHendelse, pdfBody = "MockPdfBody"), headers)),
+                        eq(HttpEntity(journalpostService.byggJournalPostRequest(sedHendelse = sedHendelse, pdfBody = "MockPdfBody").toString(), headers)),
                         eq(String::class.java))
 
         journalpostService.opprettJournalpost(sedHendelse = sedHendelse, pdfBody = "MockPdfBody", forsokFerdigstill = false)


### PR DESCRIPTION
grensesnittene foretrekker tomme felter istedet for felter med verdi "null" i json requester