### PR TITLE
Legges rinaSakId til i tilleggsopplysninger

### DIFF
--- a/src/main/kotlin/no/nav/eessi/pensjon/journalforing/JournalforingService.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/journalforing/JournalforingService.kt
@@ -65,6 +65,7 @@ class JournalforingService(private val euxService: EuxService,
             val (documents, uSupporterteVedlegg) = pdfService.parseJsonDocuments(sedDokumenterJSON, sedHendelse.sedType!!)
 
             val journalpostId = journalpostService.opprettJournalpost(
+                    rinaSakId = sedHendelse.rinaSakId,
                     navBruker= fnr,
                     personNavn= personNavn,
                     avsenderId= sedHendelse.avsenderId,

--- a/src/main/kotlin/no/nav/eessi/pensjon/services/journalpost/JournalpostService.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/services/journalpost/JournalpostService.kt
@@ -28,11 +28,13 @@ class JournalpostService(
 
     private val logger: Logger by lazy { LoggerFactory.getLogger(JournalpostService::class.java) }
     private val mapper = jacksonObjectMapper()
+    private final val TILLEGGSOPPLYSNING_RINA_SAK_ID_KEY = "eessi_pensjon_rinasakid"
 
     @Value("\${no.nav.orgnummer}")
     private lateinit var navOrgnummer: String
 
     fun opprettJournalpost(
+            rinaSakId: String,
             navBruker: String?,
             personNavn: String?,
             avsenderId: String,
@@ -63,6 +65,7 @@ class JournalpostService(
         val journalpostType = populerJournalpostType(sedHendelseType)
         val sak = populerSak(arkivsaksnummer, arkivsaksystem)
         val tema = BucType.valueOf(bucType).TEMA
+        val tilleggsopplysninger = populerTilleggsopplysninger(rinaSakId)
         val tittel = "${journalpostType.decode()} $sedType"
 
         val requestBody = JournalpostRequest(
@@ -76,6 +79,7 @@ class JournalpostService(
                 kanal,
                 sak,
                 tema,
+                tilleggsopplysninger,
                 tittel)
 
 
@@ -107,6 +111,10 @@ class JournalpostService(
                 throw RuntimeException("Feil ved opprettelse av journalpost, $ex", ex)
             }
         }
+    }
+
+    private fun populerTilleggsopplysninger(rinaSakId: String): List<Tilleggsopplysning> {
+        return listOf(Tilleggsopplysning(TILLEGGSOPPLYSNING_RINA_SAK_ID_KEY, rinaSakId))
     }
 
     private fun populerAvsenderMottaker(

--- a/src/main/kotlin/no/nav/eessi/pensjon/services/journalpost/Models.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/services/journalpost/Models.kt
@@ -16,7 +16,7 @@ import java.io.IOException
 
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class JournalPostResponse(
+class JournalPostResponse(
     val journalpostId: String,
     val journalstatus: String,
     val melding: String? = null,
@@ -28,7 +28,7 @@ data class JournalPostResponse(
     }
 }
 
-data class JournalpostRequest(
+class JournalpostRequest(
         val avsenderMottaker: AvsenderMottaker,
         val behandlingstema: String? = null,
         val bruker: Bruker? = null,
@@ -41,7 +41,7 @@ data class JournalpostRequest(
         val kanal: String? = "EESSI",
         val sak: Sak? = null,
         val tema: String = "PEN", //REQUIRED
-  //  val tilleggsopplysninger: List<Tilleggsopplysninger>? = null,
+        val tilleggsopplysninger: List<Tilleggsopplysning>? = null,
         val tittel: String //REQUIRED
 ){
     companion object {
@@ -64,7 +64,7 @@ enum class JournalpostType: Code {
     }
 }
 
-data class Sak(
+class Sak(
     val arkivsaksnummer: String, //REQUIRED
     val arkivsaksystem: String //REQUIRED
 )
@@ -74,7 +74,7 @@ data class Sak(
  *
  * https://confluence.adeo.no/display/BOA/Type%3A+AvsenderMottaker
  */
-data class AvsenderMottaker(
+class AvsenderMottaker(
     val id: String?,
     val idType: IdType?
 )
@@ -84,9 +84,14 @@ enum class IdType {
     ORGNR
 }
 
-data class Bruker(
+class Bruker(
     val id: String, //REQUIRED
     val idType: String = "FNR" //REQUIRED
+)
+
+class Tilleggsopplysning(
+        val nokkel: String, //REQUIRED
+        val verdi: String //REQUIRED
 )
 
 interface Code {

--- a/src/test/kotlin/no/nav/eessi/pensjon/journalforing/JournalforingServiceTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/journalforing/JournalforingServiceTest.kt
@@ -102,6 +102,7 @@ class JournalforingServiceTest {
         doReturn("123")
                 .`when`(journalpostService)
                 .opprettJournalpost(
+                        rinaSakId = anyOrNull(),
                         navBruker= anyOrNull(),
                         personNavn= anyOrNull(),
                         avsenderId= anyOrNull(),
@@ -148,6 +149,7 @@ class JournalforingServiceTest {
         journalforingService.journalfor(String(Files.readAllBytes(Paths.get("src/test/resources/sed/FB_BUC_01.json"))), HendelseType.SENDT )
         verify(oppgaveService, times(0)).opprettOppgave(any(), any(), any(), any(), any(), any(), any())
         verify(journalpostService, times(0)).opprettJournalpost(
+                rinaSakId= anyOrNull(),
                 navBruker= anyOrNull(),
                 personNavn= anyOrNull(),
                 avsenderId= anyOrNull(),
@@ -180,6 +182,7 @@ class JournalforingServiceTest {
         verify(euxService).hentFodselsDatoFraSed(eq("147729"), eq("b12e06dda2c7474b9998c7139c841646"))
 
         verify(journalpostService).opprettJournalpost(
+                rinaSakId = anyOrNull(),
                 navBruker= eq("12378945601"),
                 personNavn= eq("Test Testesen"),
                 avsenderId= eq("NO:NAVT003"),
@@ -217,6 +220,7 @@ class JournalforingServiceTest {
         verify(euxService).hentFodselsDatoFraSed(eq("147730"), eq("b12e06dda2c7474b9998c7139c841646"))
 
         verify(journalpostService).opprettJournalpost(
+                rinaSakId = anyOrNull(),
                 navBruker= eq("12378945602"),
                 personNavn= eq("Test Testesen"),
                 avsenderId= eq("NO:NAVT003"),
@@ -265,6 +269,7 @@ class JournalforingServiceTest {
         verify(euxService).hentFodselsDatoFraSed(eq("148161"), eq("f899bf659ff04d20bc8b978b186f1ecc"))
 
         verify(journalpostService).opprettJournalpost(
+                rinaSakId = anyOrNull(),
                 navBruker= eq(null),
                 personNavn= eq(null),
                 avsenderId= eq("NO:NAVT003"),
@@ -304,6 +309,7 @@ class JournalforingServiceTest {
         verify(euxService).hentFodselsDatoFraSed(eq("147729"), eq("b12e06dda2c7474b9998c7139c841646"))
 
         verify(journalpostService).opprettJournalpost(
+                rinaSakId = anyOrNull(),
                 navBruker= eq("12378945601"),
                 personNavn= eq("Test Testesen"),
                 avsenderId= eq("NO:NAVT003"),
@@ -352,6 +358,7 @@ class JournalforingServiceTest {
         journalforingService.journalfor(String(Files.readAllBytes(Paths.get("src/test/resources/sed/FB_BUC_01.json"))), HendelseType.SENDT )
         verify(oppgaveService, times(0)).opprettOppgave(any(), any(), any(), any(), any(), any(), any())
         verify(journalpostService, times(0)).opprettJournalpost(
+                rinaSakId = anyOrNull(),
                 navBruker= anyOrNull(),
                 personNavn= anyOrNull(),
                 avsenderId= anyOrNull(),
@@ -383,6 +390,7 @@ class JournalforingServiceTest {
         verify(euxService).hentFodselsDatoFraSed(eq("147729"), eq("b12e06dda2c7474b9998c7139c841646"))
 
         verify(journalpostService).opprettJournalpost(
+                rinaSakId = anyOrNull(),
                 navBruker= eq("12378945601"),
                 personNavn= eq("Test Testesen"),
                 avsenderId= eq("NO:NAVT003"),
@@ -423,6 +431,7 @@ class JournalforingServiceTest {
         verify(euxService).hentFodselsDatoFraSed(eq("147730"), eq("b12e06dda2c7474b9998c7139c841646"))
 
         verify(journalpostService).opprettJournalpost(
+                rinaSakId = anyOrNull(),
                 navBruker= eq("12378945602"),
                 personNavn= eq("Test Testesen"),
                 avsenderId= eq("NO:NAVT003"),
@@ -470,6 +479,7 @@ class JournalforingServiceTest {
         verify(euxService).hentFodselsDatoFraSed(eq("148161"), eq("f899bf659ff04d20bc8b978b186f1ecc"))
 
         verify(journalpostService).opprettJournalpost(
+                rinaSakId = anyOrNull(),
                 navBruker= eq(null),
                 personNavn= eq(null),
                 avsenderId= eq("NO:NAVT003"),
@@ -509,6 +519,7 @@ class JournalforingServiceTest {
 
 
         verify(journalpostService).opprettJournalpost(
+                rinaSakId = anyOrNull(),
                 navBruker= eq("12378945601"),
                 personNavn= eq("Test Testesen"),
                 avsenderId= eq("NO:NAVT003"),

--- a/src/test/kotlin/no/nav/eessi/pensjon/services/journalpost/JournalpostServiceTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/services/journalpost/JournalpostServiceTest.kt
@@ -51,6 +51,7 @@ class JournalpostServiceTest {
                         eq(String::class.java))
 
         val journalpostResponse = journalpostService.opprettJournalpost(
+                rinaSakId = "1111",
                 navBruker= "12345678912",
                 personNavn= "navn navnesen",
                 avsenderId= "NO:NAVT003",
@@ -98,6 +99,7 @@ class JournalpostServiceTest {
 
         assertThrows<RuntimeException> {
             journalpostService.opprettJournalpost(
+                    rinaSakId = "1111",
                     navBruker = "12345678912",
                     personNavn = "navn navnesen",
                     avsenderId = "NO:NAVT003",

--- a/src/test/resources/journalpost/journalpostRequest.json
+++ b/src/test/resources/journalpost/journalpostRequest.json
@@ -31,5 +31,11 @@
     "arkivsaksystem": "GSAK"
   },
   "tema": "PEN",
+  "tilleggsopplysninger": [
+    {
+      "nokkel":"eessi_pensjon_rinasakid",
+      "verdi":"1111"
+    }
+  ],
   "tittel": "Inngående P2000 - Krav om alderspensjon"
 }


### PR DESCRIPTION
Dette skal brukes i forbindelse med å finne bucer på personer som ikke har oppgitt fnr i mottatte SEDer i RINA, en bedre løsning kommer senere hvor vi lager en egen identifiseringsapplikasjon for ID-og fordelingsenheten