### PR TITLE
Teste resterende buc

### DIFF
--- a/src/main/kotlin/no/nav/eessi/pensjon/journalforing/JournalforingService.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/journalforing/JournalforingService.kt
@@ -72,18 +72,18 @@ class JournalforingService(private val euxKlient: EuxKlient,
 
                 // Oppretter journalpost
                 val journalPostResponse = journalpostService.opprettJournalpost(
-                    rinaSakId = sedHendelseModel.rinaSakId,
-                    fnr = identifisertPerson?.personRelasjon?.fnr,
-                    personNavn = identifisertPerson?.personNavn,
-                    bucType = sedHendelseModel.bucType,
-                    sedType = sedHendelseModel.sedType,
-                    sedHendelseType = hendelseType,
-                    journalfoerendeEnhet = tildeltEnhet,
-                    arkivsaksnummer = arkivsaksnummer,
-                    dokumenter = documents,
-                    avsenderLand = sedHendelseModel.avsenderLand,
-                    avsenderNavn = sedHendelseModel.avsenderNavn,
-                    ytelseType = ytelseType
+                        rinaSakId = sedHendelseModel.rinaSakId,
+                        fnr = identifisertPerson?.personRelasjon?.fnr,
+                        personNavn = identifisertPerson?.personNavn,
+                        bucType = sedHendelseModel.bucType!!,
+                        sedType = sedHendelseModel.sedType,
+                        sedHendelseType = hendelseType,
+                        journalfoerendeEnhet = tildeltEnhet,
+                        arkivsaksnummer = arkivsaksnummer,
+                        dokumenter = documents,
+                        avsenderLand = sedHendelseModel.avsenderLand,
+                        avsenderNavn = sedHendelseModel.avsenderNavn,
+                        ytelseType = ytelseType
                 )
 
                 // Oppdaterer distribusjonsinfo

--- a/src/main/kotlin/no/nav/eessi/pensjon/listeners/GyldigeHendelser.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/listeners/GyldigeHendelser.kt
@@ -12,14 +12,14 @@ class GyldigeHendelser {
 
     fun mottattHendelse(hendelse: SedHendelseModel) =
             when {
-                hendelse.bucType == BucType.UKJENT -> false
+                hendelse.bucType == null -> false
                 hendelse.bucType in gyldigeInnkommendeBucTyper || gyldigSektorKode == hendelse.sektorKode -> true
                 else -> false
             }
 
     fun sendtHendelse(hendelse: SedHendelseModel) =
             when {
-                hendelse.bucType == BucType.UKJENT -> false
+                hendelse.bucType == null -> false
                 gyldigUtgaaendeBucType == hendelse.bucType || gyldigSektorKode == hendelse.sektorKode -> true
                 else -> false
             }

--- a/src/main/kotlin/no/nav/eessi/pensjon/models/BucType.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/models/BucType.kt
@@ -1,6 +1,5 @@
 package no.nav.eessi.pensjon.models
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonValue
 
 // https://confluence.adeo.no/display/BOA/Behandlingstema
@@ -17,6 +16,7 @@ enum class Tema(@JsonValue val kode: String) {
     UFORETRYGD("UFO")
 }
 
+// https://confluence.adeo.no/display/EP/Oversikt+BUC+og+SED
 enum class BucType(val behandlingstema: Behandlingstema, val tema: Tema) {
     P_BUC_01(Behandlingstema.ALDERSPENSJON, Tema.PENSJON),
     P_BUC_02(Behandlingstema.GJENLEVENDEPENSJON, Tema.PENSJON),
@@ -29,16 +29,5 @@ enum class BucType(val behandlingstema: Behandlingstema, val tema: Tema) {
     P_BUC_09(Behandlingstema.ALDERSPENSJON, Tema.PENSJON),
     P_BUC_10(Behandlingstema.ALDERSPENSJON, Tema.PENSJON),
     H_BUC_07(Behandlingstema.ALDERSPENSJON, Tema.PENSJON),
-    R_BUC_02(Behandlingstema.TILBAKEBETALING, Tema.PENSJON),
-    UKJENT;
-
-    constructor()
-
-    companion object {
-        @JvmStatic
-        @JsonCreator
-        fun from(s: String?): BucType {
-            return values().firstOrNull { it.name == s } ?: UKJENT
-        }
-    }
+    R_BUC_02(Behandlingstema.TILBAKEBETALING, Tema.PENSJON)
 }

--- a/src/main/kotlin/no/nav/eessi/pensjon/oppgaverouting/BucTilEnhetHandler.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/oppgaverouting/BucTilEnhetHandler.kt
@@ -24,7 +24,7 @@ interface BucTilEnhetHandler {
 
 class BucTilEnhetHandlerCreator {
     companion object {
-        fun getHandler(type: BucType?): BucTilEnhetHandler {
+        fun getHandler(type: BucType): BucTilEnhetHandler {
             return when (type) {
                 BucType.P_BUC_01 -> Pbuc01()
                 BucType.P_BUC_02 -> Pbuc02()
@@ -38,7 +38,6 @@ class BucTilEnhetHandlerCreator {
                 BucType.P_BUC_10 -> Pbuc10()
                 BucType.H_BUC_07 -> Hbuc07()
                 BucType.R_BUC_02 -> Rbuc02()
-                else -> throw RuntimeException("BucType $type er ukjent/ugyldig")
             }
         }
     }

--- a/src/main/kotlin/no/nav/eessi/pensjon/oppgaverouting/BucTilEnhetHandler.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/oppgaverouting/BucTilEnhetHandler.kt
@@ -31,10 +31,14 @@ class BucTilEnhetHandlerCreator {
                 BucType.P_BUC_03 -> Pbuc03()
                 BucType.P_BUC_04 -> Pbuc04()
                 BucType.P_BUC_05 -> Pbuc05()
+                BucType.P_BUC_06,
+                BucType.P_BUC_07,
+                BucType.P_BUC_08,
+                BucType.P_BUC_09 -> DefaultBucTilEnhetHandler()
                 BucType.P_BUC_10 -> Pbuc10()
                 BucType.H_BUC_07 -> Hbuc07()
                 BucType.R_BUC_02 -> Rbuc02()
-                else -> DefaultBucTilEnhetHandler() // Felles for P_BUC_05, 06, 07, 08, 09
+                else -> throw RuntimeException("BucType $type er ukjent/ugyldig")
             }
         }
     }

--- a/src/main/kotlin/no/nav/eessi/pensjon/oppgaverouting/OppgaveRoutingRequest.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/oppgaverouting/OppgaveRoutingRequest.kt
@@ -45,7 +45,7 @@ class OppgaveRoutingRequest(
                     hendelseType,
                     sakInformasjon,
                     identifisertPerson,
-                    sedHendelseModel.bucType
+                    sedHendelseModel.bucType!!
             )
         }
     }

--- a/src/main/kotlin/no/nav/eessi/pensjon/oppgaverouting/OppgaveRoutingRequest.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/oppgaverouting/OppgaveRoutingRequest.kt
@@ -21,7 +21,7 @@ class OppgaveRoutingRequest(
         val hendelseType: HendelseType,
         val sakInformasjon: SakInformasjon? = null,
         val identifisertPerson: IdentifisertPerson? = null,
-        val bucType: BucType? = null
+        val bucType: BucType
 ) {
     val bosatt = Bosatt.fraLandkode(landkode)
 

--- a/src/main/kotlin/no/nav/eessi/pensjon/oppgaverouting/Pbuc04.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/oppgaverouting/Pbuc04.kt
@@ -2,11 +2,14 @@ package no.nav.eessi.pensjon.oppgaverouting
 
 import no.nav.eessi.pensjon.models.Enhet
 
+/**
+ * P_BUC_04: Anmodning  om opplysninger om perioder med omsorg for barn
+ */
 class Pbuc04 : BucTilEnhetHandler {
     override fun hentEnhet(request: OppgaveRoutingRequest): Enhet {
         return when {
             erStrengtFortrolig(request.diskresjonskode) -> Enhet.DISKRESJONSKODE
-            kanAutomatiskJournalfores(request)-> Enhet.AUTOMATISK_JOURNALFORING
+            kanAutomatiskJournalfores(request) -> Enhet.AUTOMATISK_JOURNALFORING
             request.bosatt == Bosatt.NORGE -> Enhet.NFP_UTLAND_AALESUND
             else -> Enhet.PENSJON_UTLAND
         }

--- a/src/main/kotlin/no/nav/eessi/pensjon/oppgaverouting/Pbuc10.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/oppgaverouting/Pbuc10.kt
@@ -51,4 +51,3 @@ class Pbuc10 : BucTilEnhetHandler {
         }
     }
 }
-

--- a/src/main/kotlin/no/nav/eessi/pensjon/sed/SedHendelseModel.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/sed/SedHendelseModel.kt
@@ -1,16 +1,17 @@
 package no.nav.eessi.pensjon.sed
 
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import no.nav.eessi.pensjon.json.mapJsonToAny
+import no.nav.eessi.pensjon.json.typeRefs
 import no.nav.eessi.pensjon.models.BucType
 import no.nav.eessi.pensjon.models.SedType
 
-data class SedHendelseModel (
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class SedHendelseModel(
         val id: Long? = 0,
         val sedId: String? = null,
         val sektorKode: String,
-        val bucType: BucType,
+        val bucType: BucType?,
         val rinaSakId: String,
         val avsenderId: String? = null,
         val avsenderNavn: String? = null,
@@ -24,12 +25,6 @@ data class SedHendelseModel (
         val navBruker: String? = null
 ) {
     companion object {
-        private val sedMapper: ObjectMapper = jacksonObjectMapper().configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true)
-
-        fun fromJson(json: String): SedHendelseModel = sedMapper.readValue(json, SedHendelseModel::class.java)
+        fun fromJson(json: String): SedHendelseModel = mapJsonToAny(json, typeRefs())
     }
 }
-
-
-
-

--- a/src/test/kotlin/no/nav/eessi/pensjon/integrasjonstest/saksflyt/JournalforingTestBase.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/integrasjonstest/saksflyt/JournalforingTestBase.kt
@@ -22,7 +22,6 @@ import no.nav.eessi.pensjon.klienter.journalpost.OpprettJournalPostResponse
 import no.nav.eessi.pensjon.klienter.journalpost.OpprettJournalpostRequest
 import no.nav.eessi.pensjon.klienter.pesys.BestemSakKlient
 import no.nav.eessi.pensjon.klienter.pesys.BestemSakService
-import no.nav.eessi.pensjon.listeners.GyldigeFunksjonerToggleNonProd
 import no.nav.eessi.pensjon.listeners.GyldigeHendelser
 import no.nav.eessi.pensjon.listeners.SedListener
 import no.nav.eessi.pensjon.models.BucType
@@ -111,7 +110,6 @@ internal open class JournalforingTestBase {
     private val sedDokumentHelper = SedDokumentHelper(fagmodulKlient, euxKlient)
     protected val bestemSakKlient: BestemSakKlient = mockk(relaxed = true)
     private val bestemSakService = BestemSakService(bestemSakKlient)
-    private val gyldigeFunksjoner = GyldigeFunksjonerToggleNonProd()
 
     protected val listener: SedListener = SedListener(
             journalforingService = journalforingService,
@@ -119,7 +117,6 @@ internal open class JournalforingTestBase {
             sedDokumentHelper = sedDokumentHelper,
             gyldigeHendelser = GyldigeHendelser(),
             bestemSakService = bestemSakService,
-            gyldigeFunksjoner = gyldigeFunksjoner,
             profile = "test"
     )
 

--- a/src/test/kotlin/no/nav/eessi/pensjon/klienter/pesys/BestemSakServiceTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/klienter/pesys/BestemSakServiceTest.kt
@@ -116,8 +116,7 @@ internal class BestemSakServiceTest {
                 { assertNull(bestemSakService.hentSakInformasjon(AKTOER_ID, BucType.P_BUC_08)) },
                 { assertNull(bestemSakService.hentSakInformasjon(AKTOER_ID, BucType.P_BUC_09)) },
                 { assertNull(bestemSakService.hentSakInformasjon(AKTOER_ID, BucType.P_BUC_10)) },
-                { assertNull(bestemSakService.hentSakInformasjon(AKTOER_ID, BucType.H_BUC_07)) },
-                { assertNull(bestemSakService.hentSakInformasjon(AKTOER_ID, BucType.UKJENT)) }
+                { assertNull(bestemSakService.hentSakInformasjon(AKTOER_ID, BucType.H_BUC_07)) }
         )
     }
 

--- a/src/test/kotlin/no/nav/eessi/pensjon/listeners/GyldigeHendelserTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/listeners/GyldigeHendelserTest.kt
@@ -32,8 +32,8 @@ internal class GyldigeHendelserTest {
     }
 
     @Test
-    fun `Mottatt hendelse med buctype UKJENT er ugyldig`() {
-        val hendelse = createDummy("P", BucType.UKJENT)
+    fun `Mottatt hendelse som mangler BucType`() {
+        val hendelse = createDummy("", null)
 
         assertFalse(gyldigeHendelser.mottattHendelse(hendelse))
     }
@@ -57,12 +57,12 @@ internal class GyldigeHendelserTest {
     }
 
     @Test
-    fun `Sendt hendelse med buctype UKJENT er ugyldig`() {
-        val hendelse = createDummy("P", BucType.UKJENT)
+    fun `Sendt hendelse som mangler BucType`() {
+        val hendelse = createDummy("", null)
 
-        assertFalse(gyldigeHendelser.sendtHendelse(hendelse))
+        assertFalse(gyldigeHendelser.mottattHendelse(hendelse))
     }
 
-    private fun createDummy(sektor: String, bucType: BucType) =
+    private fun createDummy(sektor: String, bucType: BucType?) =
             SedHendelseModel(sektorKode = sektor, bucType = bucType, rinaSakId = "12345", rinaDokumentId = "654634")
 }

--- a/src/test/kotlin/no/nav/eessi/pensjon/oppgaverouting/BucHandlerTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/oppgaverouting/BucHandlerTest.kt
@@ -3,7 +3,6 @@ package no.nav.eessi.pensjon.oppgaverouting
 import no.nav.eessi.pensjon.models.BucType
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 
@@ -44,13 +43,6 @@ internal class BucHandlerTest {
     fun `P_BUC_06, 07, 08, og 09 skal brukes default handler`(bucType: BucType) {
         val handler = BucTilEnhetHandlerCreator.getHandler(bucType)
         assertTrue(handler is DefaultBucTilEnhetHandler)
-    }
-
-    @Test
-    fun `Ukjent BucType skal kaste exception`() {
-        assertThrows<RuntimeException> {
-            BucTilEnhetHandlerCreator.getHandler(null)
-        }
     }
 
 }

--- a/src/test/kotlin/no/nav/eessi/pensjon/oppgaverouting/BucHandlerTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/oppgaverouting/BucHandlerTest.kt
@@ -3,14 +3,14 @@ package no.nav.eessi.pensjon.oppgaverouting
 import no.nav.eessi.pensjon.models.BucType
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 
 internal class BucHandlerTest {
 
     @Test
     fun `Verifiser at riktig handler blir valgt`() {
-        val resultatNull = BucTilEnhetHandlerCreator.getHandler(null)
-        assertTrue(resultatNull is DefaultBucTilEnhetHandler)
-
         // P_PUC_*
         val pbuc01 = BucTilEnhetHandlerCreator.getHandler(BucType.P_BUC_01)
         assertTrue(pbuc01 is Pbuc01)
@@ -27,18 +27,6 @@ internal class BucHandlerTest {
         val pbuc05 = BucTilEnhetHandlerCreator.getHandler(BucType.P_BUC_05)
         assertTrue(pbuc05 is Pbuc05)
 
-        val pbuc06 = BucTilEnhetHandlerCreator.getHandler(BucType.P_BUC_06)
-        assertTrue(pbuc06 is DefaultBucTilEnhetHandler)
-
-        val pbuc07 = BucTilEnhetHandlerCreator.getHandler(BucType.P_BUC_07)
-        assertTrue(pbuc07 is DefaultBucTilEnhetHandler)
-
-        val pbuc08 = BucTilEnhetHandlerCreator.getHandler(BucType.P_BUC_08)
-        assertTrue(pbuc08 is DefaultBucTilEnhetHandler)
-
-        val pbuc09 = BucTilEnhetHandlerCreator.getHandler(BucType.P_BUC_09)
-        assertTrue(pbuc09 is DefaultBucTilEnhetHandler)
-
         val pbuc10 = BucTilEnhetHandlerCreator.getHandler(BucType.P_BUC_10)
         assertTrue(pbuc10 is Pbuc10)
 
@@ -50,4 +38,19 @@ internal class BucHandlerTest {
         val rbuc02 = BucTilEnhetHandlerCreator.getHandler(BucType.R_BUC_02)
         assertTrue(rbuc02 is Rbuc02)
     }
+
+    @ParameterizedTest
+    @EnumSource(value = BucType::class, names = ["P_BUC_06", "P_BUC_07", "P_BUC_08", "P_BUC_09"])
+    fun `P_BUC_06, 07, 08, og 09 skal brukes default handler`(bucType: BucType) {
+        val handler = BucTilEnhetHandlerCreator.getHandler(bucType)
+        assertTrue(handler is DefaultBucTilEnhetHandler)
+    }
+
+    @Test
+    fun `Ukjent BucType skal kaste exception`() {
+        assertThrows<RuntimeException> {
+            BucTilEnhetHandlerCreator.getHandler(null)
+        }
+    }
+
 }

--- a/src/test/kotlin/no/nav/eessi/pensjon/oppgaverouting/DefaultBucTilEnhetHandlerTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/oppgaverouting/DefaultBucTilEnhetHandlerTest.kt
@@ -1,0 +1,75 @@
+package no.nav.eessi.pensjon.oppgaverouting
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.eessi.pensjon.models.BucType
+import no.nav.eessi.pensjon.models.Enhet
+import no.nav.eessi.pensjon.personidentifisering.helpers.Diskresjonskode
+import no.nav.eessi.pensjon.personidentifisering.helpers.Fodselsnummer
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+internal class DefaultBucTilEnhetHandlerTest {
+
+    companion object {
+        private const val FNR_OVER_60 = "09035225916"   // SLAPP SKILPADDE
+        private const val FNR_VOKSEN = "11067122781"    // KRAFTIG VEGGPRYD
+        private const val FNR_BARN = "12011577847"      // STERK BUSK
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = BucType::class, names = ["P_BUC_06", "P_BUC_07", "P_BUC_08", "P_BUC_09"])
+    fun `Sjekk diskresjonskode blir behandlet korrekt`(bucType: BucType) {
+        val request = mockk<OppgaveRoutingRequest>(relaxed = true)
+
+        val handler = BucTilEnhetHandlerCreator.getHandler(bucType)
+
+        // SPSF er strengt fortrolig og skal returnere Enhet.DISKRESJONSKODE (vikafossen)
+        every { request.diskresjonskode } returns Diskresjonskode.SPSF
+        assertEquals(Enhet.DISKRESJONSKODE, handler.hentEnhet(request))
+
+        // SPSF er mindre fortrolig og følger vanlig saksflyt
+        every { request.diskresjonskode } returns Diskresjonskode.SPFO
+        assertNotEquals(Enhet.DISKRESJONSKODE, handler.hentEnhet(request))
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = BucType::class, names = ["P_BUC_06", "P_BUC_07", "P_BUC_08", "P_BUC_09"])
+    fun `Bosatt norge`(bucType: BucType) {
+        val request = mockk<OppgaveRoutingRequest>(relaxed = true) {
+            every { bosatt } returns Bosatt.NORGE
+        }
+
+        val handler = BucTilEnhetHandlerCreator.getHandler(bucType)
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_OVER_60)!!.getBirthDate()
+        assertEquals(Enhet.NFP_UTLAND_AALESUND, handler.hentEnhet(request))
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_BARN)!!.getBirthDate()
+        assertEquals(Enhet.NFP_UTLAND_AALESUND, handler.hentEnhet(request))
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_VOKSEN)!!.getBirthDate()
+        assertEquals(Enhet.UFORE_UTLANDSTILSNITT, handler.hentEnhet(request))
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = BucType::class, names = ["P_BUC_06", "P_BUC_07", "P_BUC_08", "P_BUC_09"])
+    fun `Bosatt utland`(bucType: BucType) {
+        val request = mockk<OppgaveRoutingRequest>(relaxed = true) {
+            every { bosatt } returns Bosatt.UTLAND
+        }
+
+        val handler = BucTilEnhetHandlerCreator.getHandler(bucType)
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_OVER_60)!!.getBirthDate()
+        assertEquals(Enhet.PENSJON_UTLAND, handler.hentEnhet(request))
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_BARN)!!.getBirthDate()
+        assertEquals(Enhet.PENSJON_UTLAND, handler.hentEnhet(request))
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_VOKSEN)!!.getBirthDate()
+        assertEquals(Enhet.UFORE_UTLAND, handler.hentEnhet(request))
+    }
+}

--- a/src/test/kotlin/no/nav/eessi/pensjon/oppgaverouting/Hbuc07Test.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/oppgaverouting/Hbuc07Test.kt
@@ -1,0 +1,67 @@
+package no.nav.eessi.pensjon.oppgaverouting
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.eessi.pensjon.models.BucType
+import no.nav.eessi.pensjon.models.Enhet
+import no.nav.eessi.pensjon.personidentifisering.helpers.Diskresjonskode
+import no.nav.eessi.pensjon.personidentifisering.helpers.Fodselsnummer
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+internal class Hbuc07Test {
+
+    companion object {
+        private const val FNR_OVER_60 = "09035225916"   // SLAPP SKILPADDE
+        private const val FNR_VOKSEN = "11067122781"    // KRAFTIG VEGGPRYD
+        private const val FNR_BARN = "12011577847"      // STERK BUSK
+    }
+
+    private val handler = BucTilEnhetHandlerCreator.getHandler(BucType.H_BUC_07)
+
+    @Test
+    fun `Sjekk diskresjonskode blir behandlet korrekt`() {
+        val request = mockk<OppgaveRoutingRequest>(relaxed = true)
+
+        // SPSF er strengt fortrolig og skal returnere Enhet.DISKRESJONSKODE (vikafossen)
+        every { request.diskresjonskode } returns Diskresjonskode.SPSF
+        assertEquals(Enhet.DISKRESJONSKODE, handler.hentEnhet(request))
+
+        // SPSF er mindre fortrolig og følger vanlig saksflyt
+        every { request.diskresjonskode } returns Diskresjonskode.SPFO
+        assertNotEquals(Enhet.DISKRESJONSKODE, handler.hentEnhet(request))
+    }
+
+    @Test
+    fun `Bosatt norge`() {
+        val request = mockk<OppgaveRoutingRequest>(relaxed = true) {
+            every { bosatt } returns Bosatt.NORGE
+        }
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_OVER_60)!!.getBirthDate()
+        assertEquals(Enhet.NFP_UTLAND_OSLO, handler.hentEnhet(request))
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_BARN)!!.getBirthDate()
+        assertEquals(Enhet.NFP_UTLAND_OSLO, handler.hentEnhet(request))
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_VOKSEN)!!.getBirthDate()
+        assertEquals(Enhet.UFORE_UTLANDSTILSNITT, handler.hentEnhet(request))
+    }
+
+    @Test
+    fun `Bosatt utland`() {
+        val request = mockk<OppgaveRoutingRequest>(relaxed = true) {
+            every { bosatt } returns Bosatt.UTLAND
+        }
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_OVER_60)!!.getBirthDate()
+        assertEquals(Enhet.PENSJON_UTLAND, handler.hentEnhet(request))
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_BARN)!!.getBirthDate()
+        assertEquals(Enhet.PENSJON_UTLAND, handler.hentEnhet(request))
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_VOKSEN)!!.getBirthDate()
+        assertEquals(Enhet.UFORE_UTLAND, handler.hentEnhet(request))
+    }
+}

--- a/src/test/kotlin/no/nav/eessi/pensjon/oppgaverouting/OppgaveRoutingServiceTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/oppgaverouting/OppgaveRoutingServiceTest.kt
@@ -4,11 +4,8 @@ import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.doThrow
 import com.nhaarman.mockitokotlin2.whenever
-import io.mockk.every
-import io.mockk.mockk
 import no.nav.eessi.pensjon.json.mapJsonToAny
 import no.nav.eessi.pensjon.json.typeRefs
-import no.nav.eessi.pensjon.models.BucType
 import no.nav.eessi.pensjon.models.BucType.H_BUC_07
 import no.nav.eessi.pensjon.models.BucType.P_BUC_01
 import no.nav.eessi.pensjon.models.BucType.P_BUC_02
@@ -41,7 +38,6 @@ import no.nav.eessi.pensjon.personidentifisering.helpers.Diskresjonskode
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Spy
 import org.mockito.junit.jupiter.MockitoExtension
@@ -85,21 +81,6 @@ class OppgaveRoutingServiceTest {
     fun `Gitt manglende fnr naar oppgave routes saa send oppgave til ID_OG_FORDELING`() {
         val enhet = routingService.route(OppgaveRoutingRequest(fdato = irrelevantDato(), landkode = MANGLER_LAND, geografiskTilknytning = dummyTilknytning, bucType = P_BUC_01, hendelseType = HendelseType.SENDT))
         assertEquals(enhet, ID_OG_FORDELING)
-    }
-
-    @Test
-    fun `Gitt ukjent BucType skal routing kaste exception`() {
-        val request = mockk<OppgaveRoutingRequest> {
-            every { aktorId } returns "010101010101"
-            every { fdato } returns irrelevantDato()
-            every { landkode } returns MANGLER_LAND
-            every { bucType } returns BucType.UKJENT
-            every { hendelseType } returns HendelseType.SENDT
-        }
-
-        assertThrows<RuntimeException> {
-            routingService.route(request)
-        }
     }
 
     @Test

--- a/src/test/kotlin/no/nav/eessi/pensjon/oppgaverouting/Pbuc03Test.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/oppgaverouting/Pbuc03Test.kt
@@ -13,9 +13,9 @@ import org.junit.jupiter.params.provider.EnumSource
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
-internal class Pbuc01Test {
+internal class Pbuc03Test {
 
-    private val handler = BucTilEnhetHandlerCreator.getHandler(BucType.P_BUC_01) as Pbuc01
+    private val handler = BucTilEnhetHandlerCreator.getHandler(BucType.P_BUC_03) as Pbuc03
 
     @Test
     fun `Inneholder diskresjonskode`() {
@@ -55,7 +55,7 @@ internal class Pbuc01Test {
             every { bosatt } returns Bosatt.NORGE
         }
 
-        assertEquals(Enhet.NFP_UTLAND_AALESUND, handler.hentEnhet(request))
+        assertEquals(Enhet.UFORE_UTLANDSTILSNITT, handler.hentEnhet(request))
     }
 
     @Test
@@ -69,6 +69,6 @@ internal class Pbuc01Test {
             every { bosatt } returns Bosatt.UTLAND
         }
 
-        assertEquals(Enhet.PENSJON_UTLAND, handler.hentEnhet(request))
+        assertEquals(Enhet.UFORE_UTLAND, handler.hentEnhet(request))
     }
 }

--- a/src/test/kotlin/no/nav/eessi/pensjon/oppgaverouting/Pbuc04Test.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/oppgaverouting/Pbuc04Test.kt
@@ -13,9 +13,9 @@ import org.junit.jupiter.params.provider.EnumSource
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
-internal class Pbuc01Test {
+internal class Pbuc04Test {
 
-    private val handler = BucTilEnhetHandlerCreator.getHandler(BucType.P_BUC_01) as Pbuc01
+    private val handler = BucTilEnhetHandlerCreator.getHandler(BucType.P_BUC_04) as Pbuc04
 
     @Test
     fun `Inneholder diskresjonskode`() {
@@ -44,10 +44,26 @@ internal class Pbuc01Test {
         assertEquals(Enhet.AUTOMATISK_JOURNALFORING, handler.hentEnhet(request))
     }
 
-    @Test
-    fun `Manuell behandling, bosatt norge`() {
+    @ParameterizedTest
+    @EnumSource(YtelseType::class)
+    fun `Mottatt hendelse skal aldri journalføres automatisk`(type: YtelseType) {
         val request = mockk<OppgaveRoutingRequest> {
             every { hendelseType } returns HendelseType.MOTTATT
+            every { diskresjonskode } returns null
+            every { ytelseType } returns type
+            every { aktorId } returns "111"
+            every { sakInformasjon?.sakId } returns "555"
+            every { bosatt } returns Bosatt.NORGE
+        }
+
+        assertNotEquals(Enhet.AUTOMATISK_JOURNALFORING, handler.hentEnhet(request))
+    }
+
+    @ParameterizedTest
+    @EnumSource(HendelseType::class)
+    fun `Manuell behandling, bosatt norge`(hendelse: HendelseType) {
+        val request = mockk<OppgaveRoutingRequest> {
+            every { hendelseType } returns hendelse
             every { diskresjonskode } returns null
             every { ytelseType } returns null
             every { aktorId } returns null
@@ -58,10 +74,11 @@ internal class Pbuc01Test {
         assertEquals(Enhet.NFP_UTLAND_AALESUND, handler.hentEnhet(request))
     }
 
-    @Test
-    fun `Manuell behandling, bosatt utland`() {
+    @ParameterizedTest
+    @EnumSource(HendelseType::class)
+    fun `Manuell behandling, bosatt utland`(hendelse: HendelseType) {
         val request = mockk<OppgaveRoutingRequest> {
-            every { hendelseType } returns HendelseType.MOTTATT
+            every { hendelseType } returns hendelse
             every { diskresjonskode } returns null
             every { ytelseType } returns null
             every { aktorId } returns null

--- a/src/test/kotlin/no/nav/eessi/pensjon/oppgaverouting/Pbuc06Test.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/oppgaverouting/Pbuc06Test.kt
@@ -1,0 +1,67 @@
+package no.nav.eessi.pensjon.oppgaverouting
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.eessi.pensjon.models.BucType
+import no.nav.eessi.pensjon.models.Enhet
+import no.nav.eessi.pensjon.personidentifisering.helpers.Diskresjonskode
+import no.nav.eessi.pensjon.personidentifisering.helpers.Fodselsnummer
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+internal class Pbuc06Test {
+
+    private val handler = BucTilEnhetHandlerCreator.getHandler(BucType.P_BUC_06) as DefaultBucTilEnhetHandler
+
+    companion object {
+        private const val FNR_OVER_60 = "09035225916"   // SLAPP SKILPADDE
+        private const val FNR_VOKSEN = "11067122781"    // KRAFTIG VEGGPRYD
+        private const val FNR_BARN = "12011577847"      // STERK BUSK
+    }
+
+    @Test
+    fun `Sjekk diskresjonskode blir behandlet korrekt`() {
+        val request = mockk<OppgaveRoutingRequest>(relaxed = true)
+
+        // SPSF er strengt fortrolig og skal returnere Enhet.DISKRESJONSKODE (vikafossen)
+        every { request.diskresjonskode } returns Diskresjonskode.SPSF
+        assertEquals(Enhet.DISKRESJONSKODE, handler.hentEnhet(request))
+
+        // SPSF er mindre fortrolig og følger vanlig saksflyt
+        every { request.diskresjonskode } returns Diskresjonskode.SPFO
+        assertNotEquals(Enhet.DISKRESJONSKODE, handler.hentEnhet(request))
+    }
+
+    @Test
+    fun `Bosatt norge`() {
+        val request = mockk<OppgaveRoutingRequest>(relaxed = true) {
+            every { bosatt } returns Bosatt.NORGE
+        }
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_OVER_60)!!.getBirthDate()
+        assertEquals(Enhet.NFP_UTLAND_AALESUND, handler.hentEnhet(request))
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_BARN)!!.getBirthDate()
+        assertEquals(Enhet.NFP_UTLAND_AALESUND, handler.hentEnhet(request))
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_VOKSEN)!!.getBirthDate()
+        assertEquals(Enhet.UFORE_UTLANDSTILSNITT, handler.hentEnhet(request))
+    }
+
+    @Test
+    fun `Bosatt utland`() {
+        val request = mockk<OppgaveRoutingRequest>(relaxed = true) {
+            every { bosatt } returns Bosatt.UTLAND
+        }
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_OVER_60)!!.getBirthDate()
+        assertEquals(Enhet.PENSJON_UTLAND, handler.hentEnhet(request))
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_BARN)!!.getBirthDate()
+        assertEquals(Enhet.PENSJON_UTLAND, handler.hentEnhet(request))
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_VOKSEN)!!.getBirthDate()
+        assertEquals(Enhet.UFORE_UTLAND, handler.hentEnhet(request))
+    }
+}

--- a/src/test/kotlin/no/nav/eessi/pensjon/oppgaverouting/Pbuc07Test.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/oppgaverouting/Pbuc07Test.kt
@@ -1,0 +1,67 @@
+package no.nav.eessi.pensjon.oppgaverouting
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.eessi.pensjon.models.BucType
+import no.nav.eessi.pensjon.models.Enhet
+import no.nav.eessi.pensjon.personidentifisering.helpers.Diskresjonskode
+import no.nav.eessi.pensjon.personidentifisering.helpers.Fodselsnummer
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+internal class Pbuc07Test {
+
+    private val handler = BucTilEnhetHandlerCreator.getHandler(BucType.P_BUC_07) as DefaultBucTilEnhetHandler
+
+    companion object {
+        private const val FNR_OVER_60 = "09035225916"   // SLAPP SKILPADDE
+        private const val FNR_VOKSEN = "11067122781"    // KRAFTIG VEGGPRYD
+        private const val FNR_BARN = "12011577847"      // STERK BUSK
+    }
+
+    @Test
+    fun `Sjekk diskresjonskode blir behandlet korrekt`() {
+        val request = mockk<OppgaveRoutingRequest>(relaxed = true)
+
+        // SPSF er strengt fortrolig og skal returnere Enhet.DISKRESJONSKODE (vikafossen)
+        every { request.diskresjonskode } returns Diskresjonskode.SPSF
+        assertEquals(Enhet.DISKRESJONSKODE, handler.hentEnhet(request))
+
+        // SPSF er mindre fortrolig og følger vanlig saksflyt
+        every { request.diskresjonskode } returns Diskresjonskode.SPFO
+        assertNotEquals(Enhet.DISKRESJONSKODE, handler.hentEnhet(request))
+    }
+
+    @Test
+    fun `Bosatt norge`() {
+        val request = mockk<OppgaveRoutingRequest>(relaxed = true) {
+            every { bosatt } returns Bosatt.NORGE
+        }
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_OVER_60)!!.getBirthDate()
+        assertEquals(Enhet.NFP_UTLAND_AALESUND, handler.hentEnhet(request))
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_BARN)!!.getBirthDate()
+        assertEquals(Enhet.NFP_UTLAND_AALESUND, handler.hentEnhet(request))
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_VOKSEN)!!.getBirthDate()
+        assertEquals(Enhet.UFORE_UTLANDSTILSNITT, handler.hentEnhet(request))
+    }
+
+    @Test
+    fun `Bosatt utland`() {
+        val request = mockk<OppgaveRoutingRequest>(relaxed = true) {
+            every { bosatt } returns Bosatt.UTLAND
+        }
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_OVER_60)!!.getBirthDate()
+        assertEquals(Enhet.PENSJON_UTLAND, handler.hentEnhet(request))
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_BARN)!!.getBirthDate()
+        assertEquals(Enhet.PENSJON_UTLAND, handler.hentEnhet(request))
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_VOKSEN)!!.getBirthDate()
+        assertEquals(Enhet.UFORE_UTLAND, handler.hentEnhet(request))
+    }
+}

--- a/src/test/kotlin/no/nav/eessi/pensjon/oppgaverouting/Pbuc08Test.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/oppgaverouting/Pbuc08Test.kt
@@ -1,0 +1,67 @@
+package no.nav.eessi.pensjon.oppgaverouting
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.eessi.pensjon.models.BucType
+import no.nav.eessi.pensjon.models.Enhet
+import no.nav.eessi.pensjon.personidentifisering.helpers.Diskresjonskode
+import no.nav.eessi.pensjon.personidentifisering.helpers.Fodselsnummer
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+internal class Pbuc08Test {
+
+    private val handler = BucTilEnhetHandlerCreator.getHandler(BucType.P_BUC_08) as DefaultBucTilEnhetHandler
+
+    companion object {
+        private const val FNR_OVER_60 = "09035225916"   // SLAPP SKILPADDE
+        private const val FNR_VOKSEN = "11067122781"    // KRAFTIG VEGGPRYD
+        private const val FNR_BARN = "12011577847"      // STERK BUSK
+    }
+
+    @Test
+    fun `Sjekk diskresjonskode blir behandlet korrekt`() {
+        val request = mockk<OppgaveRoutingRequest>(relaxed = true)
+
+        // SPSF er strengt fortrolig og skal returnere Enhet.DISKRESJONSKODE (vikafossen)
+        every { request.diskresjonskode } returns Diskresjonskode.SPSF
+        assertEquals(Enhet.DISKRESJONSKODE, handler.hentEnhet(request))
+
+        // SPSF er mindre fortrolig og følger vanlig saksflyt
+        every { request.diskresjonskode } returns Diskresjonskode.SPFO
+        assertNotEquals(Enhet.DISKRESJONSKODE, handler.hentEnhet(request))
+    }
+
+    @Test
+    fun `Bosatt norge`() {
+        val request = mockk<OppgaveRoutingRequest>(relaxed = true) {
+            every { bosatt } returns Bosatt.NORGE
+        }
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_OVER_60)!!.getBirthDate()
+        assertEquals(Enhet.NFP_UTLAND_AALESUND, handler.hentEnhet(request))
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_BARN)!!.getBirthDate()
+        assertEquals(Enhet.NFP_UTLAND_AALESUND, handler.hentEnhet(request))
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_VOKSEN)!!.getBirthDate()
+        assertEquals(Enhet.UFORE_UTLANDSTILSNITT, handler.hentEnhet(request))
+    }
+
+    @Test
+    fun `Bosatt utland`() {
+        val request = mockk<OppgaveRoutingRequest>(relaxed = true) {
+            every { bosatt } returns Bosatt.UTLAND
+        }
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_OVER_60)!!.getBirthDate()
+        assertEquals(Enhet.PENSJON_UTLAND, handler.hentEnhet(request))
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_BARN)!!.getBirthDate()
+        assertEquals(Enhet.PENSJON_UTLAND, handler.hentEnhet(request))
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_VOKSEN)!!.getBirthDate()
+        assertEquals(Enhet.UFORE_UTLAND, handler.hentEnhet(request))
+    }
+}

--- a/src/test/kotlin/no/nav/eessi/pensjon/oppgaverouting/Pbuc09Test.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/oppgaverouting/Pbuc09Test.kt
@@ -1,0 +1,67 @@
+package no.nav.eessi.pensjon.oppgaverouting
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.eessi.pensjon.models.BucType
+import no.nav.eessi.pensjon.models.Enhet
+import no.nav.eessi.pensjon.personidentifisering.helpers.Diskresjonskode
+import no.nav.eessi.pensjon.personidentifisering.helpers.Fodselsnummer
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+internal class Pbuc09Test {
+
+    private val handler = BucTilEnhetHandlerCreator.getHandler(BucType.P_BUC_09) as DefaultBucTilEnhetHandler
+
+    companion object {
+        private const val FNR_OVER_60 = "09035225916"   // SLAPP SKILPADDE
+        private const val FNR_VOKSEN = "11067122781"    // KRAFTIG VEGGPRYD
+        private const val FNR_BARN = "12011577847"      // STERK BUSK
+    }
+
+    @Test
+    fun `Sjekk diskresjonskode blir behandlet korrekt`() {
+        val request = mockk<OppgaveRoutingRequest>(relaxed = true)
+
+        // SPSF er strengt fortrolig og skal returnere Enhet.DISKRESJONSKODE (vikafossen)
+        every { request.diskresjonskode } returns Diskresjonskode.SPSF
+        assertEquals(Enhet.DISKRESJONSKODE, handler.hentEnhet(request))
+
+        // SPSF er mindre fortrolig og følger vanlig saksflyt
+        every { request.diskresjonskode } returns Diskresjonskode.SPFO
+        assertNotEquals(Enhet.DISKRESJONSKODE, handler.hentEnhet(request))
+    }
+
+    @Test
+    fun `Bosatt norge`() {
+        val request = mockk<OppgaveRoutingRequest>(relaxed = true) {
+            every { bosatt } returns Bosatt.NORGE
+        }
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_OVER_60)!!.getBirthDate()
+        assertEquals(Enhet.NFP_UTLAND_AALESUND, handler.hentEnhet(request))
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_BARN)!!.getBirthDate()
+        assertEquals(Enhet.NFP_UTLAND_AALESUND, handler.hentEnhet(request))
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_VOKSEN)!!.getBirthDate()
+        assertEquals(Enhet.UFORE_UTLANDSTILSNITT, handler.hentEnhet(request))
+    }
+
+    @Test
+    fun `Bosatt utland`() {
+        val request = mockk<OppgaveRoutingRequest>(relaxed = true) {
+            every { bosatt } returns Bosatt.UTLAND
+        }
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_OVER_60)!!.getBirthDate()
+        assertEquals(Enhet.PENSJON_UTLAND, handler.hentEnhet(request))
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_BARN)!!.getBirthDate()
+        assertEquals(Enhet.PENSJON_UTLAND, handler.hentEnhet(request))
+
+        every { request.fdato } returns Fodselsnummer.fra(FNR_VOKSEN)!!.getBirthDate()
+        assertEquals(Enhet.UFORE_UTLAND, handler.hentEnhet(request))
+    }
+}

--- a/src/test/kotlin/no/nav/eessi/pensjon/oppgaverouting/Pbuc10Test.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/oppgaverouting/Pbuc10Test.kt
@@ -45,6 +45,7 @@ internal class Pbuc10Test {
 
         assertEquals(Enhet.ID_OG_FORDELING, handler.hentEnhet(request))
     }
+
     @Test
     fun `Kan automatisk journalføres`() {
         val request = mockk<OppgaveRoutingRequest>(relaxed = true) {

--- a/src/test/kotlin/no/nav/eessi/pensjon/sed/BucTypeTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/sed/BucTypeTest.kt
@@ -5,27 +5,10 @@ import no.nav.eessi.pensjon.json.toJson
 import no.nav.eessi.pensjon.json.typeRefs
 import no.nav.eessi.pensjon.models.BucType
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 
 internal class BucTypeTest {
-
-    @Test
-    fun `Sjekker at UKJENT BucType ikke feiler`() {
-        val json = """{
-            "sektorKode" : "R",
-            "bucType" : "NOE DUMT",
-            "rinaSakId" : "123456",
-            "rinaDokumentId" : "1234"
-        }""".trimMargin()
-
-        val model = SedHendelseModel.fromJson(json)
-        assertEquals(BucType.UKJENT, model.bucType)
-
-        val ukjentBucType = mapJsonToAny("\"buc finnes ikke\"", typeRefs<BucType>())
-        assertEquals(BucType.UKJENT, ukjentBucType)
-    }
 
     @ParameterizedTest
     @EnumSource(BucType::class)

--- a/src/test/kotlin/no/nav/eessi/pensjon/sed/SedHendelseModelSerdeTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/sed/SedHendelseModelSerdeTest.kt
@@ -3,12 +3,12 @@ package no.nav.eessi.pensjon.sed
 import no.nav.eessi.pensjon.json.toJson
 import no.nav.eessi.pensjon.models.BucType
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
 
 internal class SedHendelseModelSerdeTest {
-
 
     @Test
     fun `Sjekk at serialisering virker`() {
@@ -43,6 +43,32 @@ internal class SedHendelseModelSerdeTest {
         val model = SedHendelseModel.fromJson(json)
 
         val result = model.toJson()
-        JSONAssert.assertEquals(json, result,JSONCompareMode.LENIENT)
+        JSONAssert.assertEquals(json, result, JSONCompareMode.LENIENT)
+    }
+
+    @Test
+    fun `Deserialisering med ugyldig bucType skal gi bucType null`() {
+        val json = """{
+            "id" : 0,
+            "sedId" : null,
+            "sektorKode" : "R",
+            "bucType" : "FB_BUC_01",
+            "rinaSakId" : "123456",
+            "avsenderId" : null,
+            "avsenderNavn" : null,
+            "avsenderLand" : null,
+            "mottakerId" : null,
+            "mottakerNavn" : null,
+            "mottakerLand" : null,
+            "rinaDokumentId" : "1234",
+            "rinaDokumentVersjon" : null,
+            "sedType" : null,
+            "navBruker" : null
+        }""".trimMargin()
+
+        val model = SedHendelseModel.fromJson(json)
+
+        assertEquals("R", model.sektorKode)
+        assertNull(model.bucType)
     }
 }


### PR DESCRIPTION
Nå er alle BUC, med unntak av P_BUC_05, enhetstestet. 

Kaster nå også feil dersom BucType ikke er en godkjent type. Skal aldri skje siden UKJENT type filtreres ut i SedListener, men tok den med som fallback. Kom gjerne med innspill til andre løsninger/forbedringer!

Enhetstest for P_BUC_05 kommer i egen PR. 