### PR TITLE
Legge til deploy-script for release-branch

### DIFF
--- a/.github/workflows/bygg_alle_brancher.yml
+++ b/.github/workflows/bygg_alle_brancher.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - '*'
       - '*/*'
+      - '!release/*'
       - '!master'
 
 jobs:

--- a/.github/workflows/deploy_release_q2.yml
+++ b/.github/workflows/deploy_release_q2.yml
@@ -1,5 +1,5 @@
-# Deployer pågående release-branch til Q2
-name: Deploy PDL-branch til Q2
+# Deployer pågående release-branch til Q1
+name: Deploy PDL-branch til Q1
 on:
   push:
     branches:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   tag_build_and_deploy:
-    name: 'Deploy til Q2'
+    name: 'Deploy til Q1'
     runs-on: ubuntu-latest
     steps:
       # GET version
@@ -40,11 +40,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: 'NAIS-deploy to Q2'
+      - name: 'NAIS-deploy to Q1'
         uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-fss
-          RESOURCE: nais/dev-fss-q2.yml
-          VARS: nais/dev-fss-q2.json
+          RESOURCE: nais/dev-fss-q1.yml
+          VARS: nais/dev-fss-q1.json
           IMAGE: ${{ env.IMAGE }}

--- a/.github/workflows/deploy_release_q2.yml
+++ b/.github/workflows/deploy_release_q2.yml
@@ -1,0 +1,50 @@
+# Deployer pågående release-branch til Q2
+name: Deploy PDL-branch til Q2
+on:
+  push:
+    branches:
+      - 'release/*'
+
+jobs:
+  tag_build_and_deploy:
+    name: 'Deploy til Q2'
+    runs-on: ubuntu-latest
+    steps:
+      # GET version
+      - name: 'Get the version'
+        uses: actions/checkout@v2
+
+      # SETTER DATO OG COMMIT VARIABEL
+      - name: 'Setter dato og commit variabel'
+        run: |
+          export TZ=CET
+          echo "DATE=$(date "+%Y-%m-%d--%H-%M-%S")" >> $GITHUB_ENV
+          echo "COMMIT_HASH=$(git rev-parse HEAD)" >> $GITHUB_ENV
+      # SETTER IMAGE VARIABEL
+      - name: 'Setter Image'
+        run: echo "IMAGE=docker.pkg.github.com/${{ github.repository }}/eessi-pensjon-journalforing:${{ env.DATE }}---${{ env.COMMIT_HASH }}" >> $GITHUB_ENV
+
+      # JAVA 11
+      - name: 'Java 11'
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: 11
+
+      # BYGGER DOCKER CONTAINER
+      - name: 'Bygg og publiser docker image'
+        run: |
+          ./gradlew build
+          docker build --tag ${{ env.IMAGE }} .
+          docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} -p ${{ secrets.GITHUB_TOKEN }}
+          docker push ${{ env.IMAGE }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'NAIS-deploy to Q2'
+        uses: nais/deploy/actions/deploy@v1
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: dev-fss
+          RESOURCE: nais/dev-fss-q2.yml
+          VARS: nais/dev-fss-q2.json
+          IMAGE: ${{ env.IMAGE }}


### PR DESCRIPTION
Forslag til github workflow script som forenkler deploy til Q1. 

Ved å si at alt som ligger på en release-branch deployes automatisk, vil det gjøre det enkelt å jobbe på større endringer som må testes i Q1. 

Så alle brancher med `release/*` vil da bli deployet. Om vi introduserer `git flow` vil det også fjerne muligheten for å ha mer enn én release-branch. 

Tanker, innspill, eller innvendinger? 