### PR TITLE
bumping av biblioteker og gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ dependencies {
 	testImplementation 'com.tngtech.archunit:archunit:0.22.0'
 
 	// Micrometer
-	implementation("io.micrometer:micrometer-registry-prometheus")
+	implementation("io.micrometer:micrometer-registry-prometheus:1.8.1")
 
 	// Eessi pensjon biblioteker
 	implementation("no.nav.eessi.pensjon:ep-metrics:${epMetricsVersion}")

--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,18 @@
 buildscript {
 
 	ext {
-		kotlinVersion = '1.5.21'
-		springBootVersion = '2.5.6'
-		cxfVersion = '3.4.2'
+		kotlinVersion = '1.6.10'
+		springBootVersion = '2.6.1'
+		cxfVersion = '3.4.5'
 		oidcTokenSupportVersion = '0.2.9'
-		logstashLogbackVersion = '6.6'
+		logstashLogbackVersion = '7.0.1'
 		pensjonInformasjonVersion = '9.4.10'
 		mockserverVersion = '5.11.2'
 		epMetricsVersion = '0.4.12'
-		epLoggingVersion = '1.0.9'
-		epSecurityStsVersion = '0.0.17'
-		epPersonoppslagVersion = '8.0.21'
-		epEuxVersion = '1.1.52'
+		epLoggingVersion = '1.0.15'
+		epSecurityStsVersion = '0.0.21'
+		epPersonoppslagVersion = '8.2.3'
+		epEuxVersion = '1.1.57'
 	}
 	repositories {
 		mavenCentral()
@@ -27,11 +27,11 @@ buildscript {
 }
 
 plugins {
-	id 'com.github.ben-manes.versions' version '0.36.0'
-	id 'se.patrikerdes.use-latest-versions' version '0.2.13'
+	id 'com.github.ben-manes.versions' version '0.39.0'
+	id 'se.patrikerdes.use-latest-versions' version '0.2.18'
 	id "org.owasp.dependencycheck" version "6.5.0.1"
-	id 'com.adarshr.test-logger' version '2.1.1'
-	id "org.sonarqube" version "3.0"
+	id 'com.adarshr.test-logger' version '3.1.0'
+	id "org.sonarqube" version "3.3"
 	id 'jacoco'
 }
 
@@ -61,11 +61,11 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-actuator:${springBootVersion}")
 
 	implementation 'com.fasterxml.jackson.module:jackson-module-kotlin'
-	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.5'
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.0'
 	implementation 'org.jetbrains.kotlin:kotlin-reflect'
 	implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 	implementation 'org.springframework.kafka:spring-kafka'
-    testImplementation('org.springframework.boot:spring-boot-starter-test:2.4.6') {
+    testImplementation('org.springframework.boot:spring-boot-starter-test:2.6.1') {
 		exclude module: 'junit'
 		exclude module: "mockito-core"
 		exclude module: "junit-vintage-engine"
@@ -88,11 +88,11 @@ dependencies {
 		exclude module: 'junit'
 	}
 	testImplementation("org.mock-server:mockserver-client-java:${mockserverVersion}")
-	testImplementation("io.mockk:mockk:1.11.0")
+	testImplementation("io.mockk:mockk:1.12.1")
 	testImplementation("com.ninja-squad:springmockk:3.0.1")
 
 	// Architecture tests
-	testImplementation 'com.tngtech.archunit:archunit:0.14.1'
+	testImplementation 'com.tngtech.archunit:archunit:0.22.0'
 
 	// Micrometer
 	implementation("io.micrometer:micrometer-registry-prometheus")
@@ -105,9 +105,9 @@ dependencies {
 	implementation("no.nav.eessi.pensjon:ep-eux:${epEuxVersion}")
 
 	// PDF box
-	implementation("org.apache.pdfbox:pdfbox-tools:2.0.22")
-	implementation("com.twelvemonkeys.imageio:imageio-jpeg:3.6.2")
-	implementation("com.twelvemonkeys.imageio:imageio-tiff:3.6.2")
+	implementation("org.apache.pdfbox:pdfbox-tools:2.0.24")
+	implementation("com.twelvemonkeys.imageio:imageio-jpeg:3.8.0")
+	implementation("com.twelvemonkeys.imageio:imageio-tiff:3.8.0")
 
 	// Logging
 	implementation("net.logstash.logback:logstash-logback-encoder:${logstashLogbackVersion}")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/no/nav/eessi/pensjon/automatisering/AutomatiseringMelding.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/automatisering/AutomatiseringMelding.kt
@@ -1,6 +1,6 @@
 package no.nav.eessi.pensjon.automatisering
 
-import no.nav.eessi.pensjon.eux.model.sed.SedType
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.models.BucType
 import no.nav.eessi.pensjon.models.HendelseType
 import no.nav.eessi.pensjon.models.Saktype

--- a/src/main/kotlin/no/nav/eessi/pensjon/buc/EuxDokumentHelper.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/buc/EuxDokumentHelper.kt
@@ -1,13 +1,13 @@
 package no.nav.eessi.pensjon.buc
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.eux.model.buc.Buc
 import no.nav.eessi.pensjon.eux.model.document.ForenkletSED
 import no.nav.eessi.pensjon.eux.model.document.SedDokumentfiler
 import no.nav.eessi.pensjon.eux.model.document.SedStatus
 import no.nav.eessi.pensjon.eux.model.sed.R005
 import no.nav.eessi.pensjon.eux.model.sed.SED
-import no.nav.eessi.pensjon.eux.model.sed.SedType
 import no.nav.eessi.pensjon.metrics.MetricsHelper
 import no.nav.eessi.pensjon.models.BucType
 import no.nav.eessi.pensjon.models.Saktype

--- a/src/main/kotlin/no/nav/eessi/pensjon/config/KafkaConfigProd.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/config/KafkaConfigProd.kt
@@ -100,7 +100,7 @@ class KafkaConfigProd(
         val factory = ConcurrentKafkaListenerContainerFactory<String, String>()
         factory.consumerFactory = onpremKafkaConsumerFactory()
         factory.containerProperties.ackMode = ContainerProperties.AckMode.MANUAL
-        factory.containerProperties.authorizationExceptionRetryInterval =  Duration.ofSeconds(4L)
+        factory.containerProperties.setAuthExceptionRetryInterval(Duration.ofSeconds(4L))
         if (kafkaErrorHandler != null) {
             factory.setErrorHandler(kafkaErrorHandler)
         }

--- a/src/main/kotlin/no/nav/eessi/pensjon/config/KafkaConfigTest.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/config/KafkaConfigTest.kt
@@ -109,7 +109,7 @@ class KafkaConfigTest(
         val factory = ConcurrentKafkaListenerContainerFactory<String, String>()
         factory.consumerFactory = onpremKafkaConsumerFactory()
         factory.containerProperties.ackMode = ContainerProperties.AckMode.MANUAL
-        factory.containerProperties.authorizationExceptionRetryInterval =  Duration.ofSeconds(4L)
+        factory.containerProperties.setAuthExceptionRetryInterval(Duration.ofSeconds(4L))
         return factory
     }
 

--- a/src/main/kotlin/no/nav/eessi/pensjon/handler/OppgaveMelding.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/handler/OppgaveMelding.kt
@@ -1,7 +1,7 @@
 package no.nav.eessi.pensjon.handler
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import no.nav.eessi.pensjon.eux.model.sed.SedType
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.json.toJson
 import no.nav.eessi.pensjon.models.Enhet
 import no.nav.eessi.pensjon.models.HendelseType

--- a/src/main/kotlin/no/nav/eessi/pensjon/journalforing/JournalforingService.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/journalforing/JournalforingService.kt
@@ -5,9 +5,9 @@ import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import no.nav.eessi.pensjon.automatisering.AutomatiseringMelding
 import no.nav.eessi.pensjon.automatisering.AutomatiseringStatistikkPublisher
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.eux.model.document.SedVedlegg
 import no.nav.eessi.pensjon.eux.model.sed.SED
-import no.nav.eessi.pensjon.eux.model.sed.SedType
 import no.nav.eessi.pensjon.handler.OppgaveHandler
 import no.nav.eessi.pensjon.handler.OppgaveMelding
 import no.nav.eessi.pensjon.handler.OppgaveType

--- a/src/main/kotlin/no/nav/eessi/pensjon/journalforing/KravInitialiseringsService.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/journalforing/KravInitialiseringsService.kt
@@ -1,8 +1,8 @@
 package no.nav.eessi.pensjon.journalforing
 
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.eux.model.sed.P2000
 import no.nav.eessi.pensjon.eux.model.sed.SED
-import no.nav.eessi.pensjon.eux.model.sed.SedType
 import no.nav.eessi.pensjon.handler.BehandleHendelseModel
 import no.nav.eessi.pensjon.handler.HendelseKode
 import no.nav.eessi.pensjon.handler.KravInitialiseringsHandler

--- a/src/main/kotlin/no/nav/eessi/pensjon/klienter/journalpost/JournalpostService.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/klienter/journalpost/JournalpostService.kt
@@ -1,7 +1,7 @@
 package no.nav.eessi.pensjon.klienter.journalpost
 
 import com.google.common.annotations.VisibleForTesting
-import no.nav.eessi.pensjon.eux.model.sed.SedType
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.models.Behandlingstema
 import no.nav.eessi.pensjon.models.BucType
 import no.nav.eessi.pensjon.models.Enhet

--- a/src/main/kotlin/no/nav/eessi/pensjon/models/sed/SedTypeUtils.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/models/sed/SedTypeUtils.kt
@@ -1,80 +1,8 @@
 package no.nav.eessi.pensjon.models.sed
 
-import no.nav.eessi.pensjon.eux.model.sed.SedType
-import no.nav.eessi.pensjon.eux.model.sed.SedType.H001
-import no.nav.eessi.pensjon.eux.model.sed.SedType.H002
-import no.nav.eessi.pensjon.eux.model.sed.SedType.H020
-import no.nav.eessi.pensjon.eux.model.sed.SedType.H021
-import no.nav.eessi.pensjon.eux.model.sed.SedType.H070
-import no.nav.eessi.pensjon.eux.model.sed.SedType.H120
-import no.nav.eessi.pensjon.eux.model.sed.SedType.H121
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P1000
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P10000
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P11000
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P12000
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P13000
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P14000
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P15000
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P2000
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P2100
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P2200
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P3000_AT
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P3000_BE
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P3000_BG
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P3000_CH
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P3000_CY
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P3000_CZ
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P3000_DE
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P3000_DK
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P3000_EE
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P3000_EL
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P3000_ES
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P3000_FI
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P3000_FR
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P3000_HR
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P3000_HU
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P3000_IE
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P3000_IS
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P3000_IT
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P3000_LI
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P3000_LT
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P3000_LU
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P3000_LV
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P3000_MT
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P3000_NL
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P3000_NO
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P3000_PL
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P3000_PT
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P3000_RO
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P3000_SE
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P3000_SI
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P3000_SK
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P3000_UK
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P4000
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P5000
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P6000
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P7000
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P8000
-import no.nav.eessi.pensjon.eux.model.sed.SedType.P9000
-import no.nav.eessi.pensjon.eux.model.sed.SedType.R004
-import no.nav.eessi.pensjon.eux.model.sed.SedType.R005
-import no.nav.eessi.pensjon.eux.model.sed.SedType.R006
-import no.nav.eessi.pensjon.eux.model.sed.SedType.X001
-import no.nav.eessi.pensjon.eux.model.sed.SedType.X002
-import no.nav.eessi.pensjon.eux.model.sed.SedType.X003
-import no.nav.eessi.pensjon.eux.model.sed.SedType.X004
-import no.nav.eessi.pensjon.eux.model.sed.SedType.X005
-import no.nav.eessi.pensjon.eux.model.sed.SedType.X006
-import no.nav.eessi.pensjon.eux.model.sed.SedType.X007
-import no.nav.eessi.pensjon.eux.model.sed.SedType.X008
-import no.nav.eessi.pensjon.eux.model.sed.SedType.X009
-import no.nav.eessi.pensjon.eux.model.sed.SedType.X010
-import no.nav.eessi.pensjon.eux.model.sed.SedType.X011
-import no.nav.eessi.pensjon.eux.model.sed.SedType.X012
-import no.nav.eessi.pensjon.eux.model.sed.SedType.X013
-import no.nav.eessi.pensjon.eux.model.sed.SedType.X050
-import no.nav.eessi.pensjon.eux.model.sed.SedType.X100
-import no.nav.eessi.pensjon.models.sed.SedTypeUtils.kanInneholdeIdentEllerFdato
+import no.nav.eessi.pensjon.eux.model.SedType
+import no.nav.eessi.pensjon.eux.model.SedType.*
+import no.nav.eessi.pensjon.models.sed.SedTypeUtils.typerMedIdentEllerFDato
 import no.nav.eessi.pensjon.models.sed.SedTypeUtils.ugyldigeTyper
 
 object SedTypeUtils {
@@ -82,7 +10,7 @@ object SedTypeUtils {
     /**
      * SED-typer som kan inneholde ident (fnr/dnr) og/eller fdato
      */
-    val kanInneholdeIdentEllerFdato: Set<SedType> = setOf(
+    val typerMedIdentEllerFDato: Set<SedType> = setOf(
         P2000, P2100, P2200, P3000_AT, P3000_BE, P3000_BG, P3000_CH, P3000_CY, P3000_CZ,
         P3000_DE, P3000_DK, P3000_EE, P3000_EL, P3000_ES, P3000_FI, P3000_FR, P3000_HR,
         P3000_HU, P3000_IE, P3000_IS, P3000_IT, P3000_LI, P3000_LT, P3000_LU, P3000_LV,
@@ -101,6 +29,6 @@ object SedTypeUtils {
     )
 }
 
-fun SedType.kanInneholdeIdentEllerFdato(): Boolean = this in kanInneholdeIdentEllerFdato
+fun SedType.kanInneholdeIdentEllerFdato(): Boolean = this in typerMedIdentEllerFDato
 
 fun SedType?.erGyldig(): Boolean = this != null && this !in ugyldigeTyper

--- a/src/main/kotlin/no/nav/eessi/pensjon/oppgaverouting/BucTilEnhetHandler.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/oppgaverouting/BucTilEnhetHandler.kt
@@ -1,6 +1,6 @@
 package no.nav.eessi.pensjon.oppgaverouting
 
-import no.nav.eessi.pensjon.eux.model.sed.SedType
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.models.BucType
 import no.nav.eessi.pensjon.models.Enhet
 import no.nav.eessi.pensjon.models.HendelseType

--- a/src/main/kotlin/no/nav/eessi/pensjon/oppgaverouting/OppgaveRoutingRequest.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/oppgaverouting/OppgaveRoutingRequest.kt
@@ -1,6 +1,6 @@
 package no.nav.eessi.pensjon.oppgaverouting
 
-import no.nav.eessi.pensjon.eux.model.sed.SedType
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.models.BucType
 import no.nav.eessi.pensjon.models.HendelseType
 import no.nav.eessi.pensjon.models.SakInformasjon

--- a/src/main/kotlin/no/nav/eessi/pensjon/oppgaverouting/Rbuc02.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/oppgaverouting/Rbuc02.kt
@@ -1,6 +1,6 @@
 package no.nav.eessi.pensjon.oppgaverouting
 
-import no.nav.eessi.pensjon.eux.model.sed.SedType
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.models.Enhet
 import no.nav.eessi.pensjon.models.HendelseType
 import no.nav.eessi.pensjon.models.Saktype

--- a/src/main/kotlin/no/nav/eessi/pensjon/pdf/PDFService.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/pdf/PDFService.kt
@@ -5,9 +5,9 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import no.nav.eessi.pensjon.buc.EuxDokumentHelper
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.eux.model.document.MimeType
 import no.nav.eessi.pensjon.eux.model.document.SedVedlegg
-import no.nav.eessi.pensjon.eux.model.sed.SedType
 import no.nav.eessi.pensjon.json.toJson
 import no.nav.eessi.pensjon.metrics.MetricsHelper
 import org.slf4j.LoggerFactory

--- a/src/main/kotlin/no/nav/eessi/pensjon/personidentifisering/PersonModel.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/personidentifisering/PersonModel.kt
@@ -1,6 +1,6 @@
 package no.nav.eessi.pensjon.personidentifisering
 
-import no.nav.eessi.pensjon.eux.model.sed.SedType
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.models.Saktype
 import no.nav.eessi.pensjon.personoppslag.Fodselsnummer
 import no.nav.eessi.pensjon.personoppslag.pdl.model.SokKriterier

--- a/src/main/kotlin/no/nav/eessi/pensjon/personidentifisering/PersonidentifiseringService.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/personidentifisering/PersonidentifiseringService.kt
@@ -2,8 +2,8 @@ package no.nav.eessi.pensjon.personidentifisering
 
 //import no.nav.eessi.pensjon.personidentifisering.helpers.FnrHelper
 import io.micrometer.core.instrument.Metrics
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.eux.model.sed.SED
-import no.nav.eessi.pensjon.eux.model.sed.SedType
 import no.nav.eessi.pensjon.json.toJson
 import no.nav.eessi.pensjon.models.BucType
 import no.nav.eessi.pensjon.models.HendelseType

--- a/src/main/kotlin/no/nav/eessi/pensjon/personidentifisering/helpers/FodselsdatoHelper.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/personidentifisering/helpers/FodselsdatoHelper.kt
@@ -1,5 +1,6 @@
 package no.nav.eessi.pensjon.personidentifisering.helpers
 
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.eux.model.sed.Bruker
 import no.nav.eessi.pensjon.eux.model.sed.P15000
 import no.nav.eessi.pensjon.eux.model.sed.P5000
@@ -7,7 +8,6 @@ import no.nav.eessi.pensjon.eux.model.sed.P6000
 import no.nav.eessi.pensjon.eux.model.sed.Person
 import no.nav.eessi.pensjon.eux.model.sed.R005
 import no.nav.eessi.pensjon.eux.model.sed.SED
-import no.nav.eessi.pensjon.eux.model.sed.SedType
 import no.nav.eessi.pensjon.eux.model.sed.X005
 import no.nav.eessi.pensjon.eux.model.sed.X008
 import no.nav.eessi.pensjon.eux.model.sed.X010

--- a/src/main/kotlin/no/nav/eessi/pensjon/personidentifisering/helpers/PersonSok.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/personidentifisering/helpers/PersonSok.kt
@@ -2,7 +2,7 @@ package no.nav.eessi.pensjon.personidentifisering.helpers
 
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
-import no.nav.eessi.pensjon.eux.model.sed.SedType
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.metrics.MetricsHelper
 import no.nav.eessi.pensjon.models.BucType
 import no.nav.eessi.pensjon.models.HendelseType

--- a/src/main/kotlin/no/nav/eessi/pensjon/personidentifisering/relasjoner/RelasjonsHandler.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/personidentifisering/relasjoner/RelasjonsHandler.kt
@@ -1,7 +1,7 @@
 package no.nav.eessi.pensjon.personidentifisering.relasjoner
 
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.eux.model.sed.SED
-import no.nav.eessi.pensjon.eux.model.sed.SedType
 import no.nav.eessi.pensjon.models.BucType
 import no.nav.eessi.pensjon.models.sed.kanInneholdeIdentEllerFdato
 import no.nav.eessi.pensjon.personidentifisering.SEDPersonRelasjon

--- a/src/main/kotlin/no/nav/eessi/pensjon/sed/SedHendelseModel.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/sed/SedHendelseModel.kt
@@ -1,7 +1,7 @@
 package no.nav.eessi.pensjon.sed
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import no.nav.eessi.pensjon.eux.model.sed.SedType
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.json.mapJsonToAny
 import no.nav.eessi.pensjon.json.typeRefs
 import no.nav.eessi.pensjon.models.BucType

--- a/src/test/kotlin/no/nav/eessi/pensjon/buc/EuxDokumentHelperTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/buc/EuxDokumentHelperTest.kt
@@ -5,6 +5,7 @@ import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.eux.model.buc.Buc
 import no.nav.eessi.pensjon.eux.model.buc.Document
 import no.nav.eessi.pensjon.eux.model.buc.Organisation
@@ -14,7 +15,6 @@ import no.nav.eessi.pensjon.eux.model.document.SedStatus
 import no.nav.eessi.pensjon.eux.model.sed.P15000
 import no.nav.eessi.pensjon.eux.model.sed.R005
 import no.nav.eessi.pensjon.eux.model.sed.SED
-import no.nav.eessi.pensjon.eux.model.sed.SedType
 import no.nav.eessi.pensjon.json.mapJsonToAny
 import no.nav.eessi.pensjon.json.toJson
 import no.nav.eessi.pensjon.json.typeRefs

--- a/src/test/kotlin/no/nav/eessi/pensjon/buc/FagmodulHelperTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/buc/FagmodulHelperTest.kt
@@ -1,10 +1,11 @@
 package no.nav.eessi.pensjon.buc
 
 import io.mockk.*
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.eux.model.sed.EessisakItem
 import no.nav.eessi.pensjon.eux.model.sed.Nav
 import no.nav.eessi.pensjon.eux.model.sed.SED
-import no.nav.eessi.pensjon.eux.model.sed.SedType
+
 import no.nav.eessi.pensjon.json.mapJsonToAny
 import no.nav.eessi.pensjon.json.typeRefs
 import no.nav.eessi.pensjon.klienter.fagmodul.FagmodulKlient

--- a/src/test/kotlin/no/nav/eessi/pensjon/handler/OppgaveMeldingSerdeTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/handler/OppgaveMeldingSerdeTest.kt
@@ -1,6 +1,7 @@
 package no.nav.eessi.pensjon.handler
 
-import no.nav.eessi.pensjon.eux.model.sed.SedType
+
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.json.mapJsonToAny
 import no.nav.eessi.pensjon.json.toJson
 import no.nav.eessi.pensjon.json.typeRefs

--- a/src/test/kotlin/no/nav/eessi/pensjon/integrasjonstest/IntegrasjonsTestConfig.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/integrasjonstest/IntegrasjonsTestConfig.kt
@@ -53,7 +53,7 @@ class IntegrasjonsTestConfig {
         val factory = ConcurrentKafkaListenerContainerFactory<String, String>()
         factory.consumerFactory = kafkaConsumerFactory()
         factory.containerProperties.ackMode = ContainerProperties.AckMode.MANUAL
-        factory.containerProperties.authorizationExceptionRetryInterval =  Duration.ofSeconds(4L)
+        factory.containerProperties.setAuthExceptionRetryInterval(Duration.ofSeconds(4L))
         return factory
     }
 

--- a/src/test/kotlin/no/nav/eessi/pensjon/integrasjonstest/saksflyt/JournalforingTestBase.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/integrasjonstest/saksflyt/JournalforingTestBase.kt
@@ -5,6 +5,7 @@ import no.nav.eessi.pensjon.automatisering.AutomatiseringStatistikkPublisher
 import no.nav.eessi.pensjon.buc.EuxDokumentHelper
 import no.nav.eessi.pensjon.buc.EuxKlient
 import no.nav.eessi.pensjon.buc.FagmodulHelper
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.eux.model.buc.Buc
 import no.nav.eessi.pensjon.eux.model.buc.Document
 import no.nav.eessi.pensjon.eux.model.buc.Organisation

--- a/src/test/kotlin/no/nav/eessi/pensjon/integrasjonstest/saksflyt/PBuc01IntegrationTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/integrasjonstest/saksflyt/PBuc01IntegrationTest.kt
@@ -5,6 +5,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.eux.model.buc.Buc
 import no.nav.eessi.pensjon.eux.model.document.ForenkletSED
 import no.nav.eessi.pensjon.eux.model.document.SedDokumentfiler
@@ -14,7 +15,7 @@ import no.nav.eessi.pensjon.eux.model.sed.P2000
 import no.nav.eessi.pensjon.eux.model.sed.P5000
 import no.nav.eessi.pensjon.eux.model.sed.P8000
 import no.nav.eessi.pensjon.eux.model.sed.SED
-import no.nav.eessi.pensjon.eux.model.sed.SedType
+
 import no.nav.eessi.pensjon.eux.model.sed.SivilstandItem
 import no.nav.eessi.pensjon.eux.model.sed.StatsborgerskapItem
 import no.nav.eessi.pensjon.handler.BehandleHendelseModel
@@ -103,9 +104,7 @@ internal class PBuc01IntegrationTest : JournalforingTestBase() {
                 assertEquals(HendelseKode.SOKNAD_OM_ALDERSPENSJON, kravMelding?.hendelsesKode)
                 assertEquals("147729", kravMelding?.bucId)
                 assertEquals(SAK_ID, kravMelding?.sakId)
-
             }
-
         }
 
         @Test
@@ -188,7 +187,6 @@ internal class PBuc01IntegrationTest : JournalforingTestBase() {
                 assertEquals(AUTOMATISK_JOURNALFORING, it.oppgaveMelding?.tildeltEnhetsnr)
                 assertEquals("0123456789000", it.oppgaveMelding?.aktoerId)
                 assertEquals(JOURNALFORING, it.oppgaveMelding?.oppgaveType)
-
             }
         }
 
@@ -304,7 +302,6 @@ internal class PBuc01IntegrationTest : JournalforingTestBase() {
         fun `Krav om Alder P2000 ingen fnr funnet benytter sokPerson som heller ikke finner person Oppgave routes til ID Og Fordeling`() {
 
             val allDocuemtActions = listOf(ForenkletSED("b12e06dda2c7474b9998c7139c841646", SedType.P2000, SedStatus.RECEIVED))
-
 
             testRunnerVoksenSokPerson(
                 FNR_VOKSEN,

--- a/src/test/kotlin/no/nav/eessi/pensjon/integrasjonstest/saksflyt/PBuc02IntegrationTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/integrasjonstest/saksflyt/PBuc02IntegrationTest.kt
@@ -5,11 +5,12 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.eux.model.document.ForenkletSED
 import no.nav.eessi.pensjon.eux.model.document.SedStatus
 import no.nav.eessi.pensjon.eux.model.sed.KravType
 import no.nav.eessi.pensjon.eux.model.sed.RelasjonTilAvdod
-import no.nav.eessi.pensjon.eux.model.sed.SedType
+
 import no.nav.eessi.pensjon.handler.OppgaveMelding
 import no.nav.eessi.pensjon.json.mapJsonToAny
 import no.nav.eessi.pensjon.json.typeRefs

--- a/src/test/kotlin/no/nav/eessi/pensjon/integrasjonstest/saksflyt/PBuc03IntegrationTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/integrasjonstest/saksflyt/PBuc03IntegrationTest.kt
@@ -4,13 +4,14 @@ import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.eux.model.document.ForenkletSED
 import no.nav.eessi.pensjon.eux.model.document.SedDokumentfiler
 import no.nav.eessi.pensjon.eux.model.document.SedStatus
 import no.nav.eessi.pensjon.eux.model.sed.KravType
 import no.nav.eessi.pensjon.eux.model.sed.P2200
 import no.nav.eessi.pensjon.eux.model.sed.SED
-import no.nav.eessi.pensjon.eux.model.sed.SedType
+
 import no.nav.eessi.pensjon.handler.BehandleHendelseModel
 import no.nav.eessi.pensjon.handler.HendelseKode
 import no.nav.eessi.pensjon.handler.OppgaveMelding

--- a/src/test/kotlin/no/nav/eessi/pensjon/integrasjonstest/saksflyt/PBuc04IntegrationTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/integrasjonstest/saksflyt/PBuc04IntegrationTest.kt
@@ -5,8 +5,9 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.eux.model.sed.SED
-import no.nav.eessi.pensjon.eux.model.sed.SedType
+
 import no.nav.eessi.pensjon.klienter.journalpost.OpprettJournalpostRequest
 import no.nav.eessi.pensjon.models.BucType
 import no.nav.eessi.pensjon.models.Enhet

--- a/src/test/kotlin/no/nav/eessi/pensjon/integrasjonstest/saksflyt/PBuc05IntegrationTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/integrasjonstest/saksflyt/PBuc05IntegrationTest.kt
@@ -1,13 +1,14 @@
 package no.nav.eessi.pensjon.integrasjonstest.saksflyt
 
 import io.mockk.*
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.eux.model.buc.Buc
 import no.nav.eessi.pensjon.eux.model.document.ForenkletSED
 import no.nav.eessi.pensjon.eux.model.document.SedStatus
 import no.nav.eessi.pensjon.eux.model.sed.P5000
 import no.nav.eessi.pensjon.eux.model.sed.P8000
 import no.nav.eessi.pensjon.eux.model.sed.SED
-import no.nav.eessi.pensjon.eux.model.sed.SedType
+
 import no.nav.eessi.pensjon.handler.OppgaveMelding
 import no.nav.eessi.pensjon.handler.OppgaveType
 import no.nav.eessi.pensjon.json.mapJsonToAny

--- a/src/test/kotlin/no/nav/eessi/pensjon/integrasjonstest/saksflyt/PBuc10IntegrationTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/integrasjonstest/saksflyt/PBuc10IntegrationTest.kt
@@ -5,6 +5,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.eux.model.document.ForenkletSED
 import no.nav.eessi.pensjon.eux.model.document.SedStatus
 import no.nav.eessi.pensjon.eux.model.sed.KravType
@@ -15,7 +16,7 @@ import no.nav.eessi.pensjon.eux.model.sed.P15000
 import no.nav.eessi.pensjon.eux.model.sed.P5000
 import no.nav.eessi.pensjon.eux.model.sed.RelasjonTilAvdod
 import no.nav.eessi.pensjon.eux.model.sed.SED
-import no.nav.eessi.pensjon.eux.model.sed.SedType
+
 import no.nav.eessi.pensjon.eux.model.sed.SivilstandItem
 import no.nav.eessi.pensjon.handler.OppgaveMelding
 import no.nav.eessi.pensjon.handler.OppgaveType

--- a/src/test/kotlin/no/nav/eessi/pensjon/journalforing/JournalforingServiceTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/journalforing/JournalforingServiceTest.kt
@@ -4,8 +4,9 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.eessi.pensjon.automatisering.AutomatiseringStatistikkPublisher
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.eux.model.sed.SED
-import no.nav.eessi.pensjon.eux.model.sed.SedType
+
 import no.nav.eessi.pensjon.handler.KravInitialiseringsHandler
 import no.nav.eessi.pensjon.handler.OppgaveHandler
 import no.nav.eessi.pensjon.klienter.journalpost.JournalpostService

--- a/src/test/kotlin/no/nav/eessi/pensjon/klienter/journalpost/JournalpostServiceTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/klienter/journalpost/JournalpostServiceTest.kt
@@ -4,7 +4,8 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
-import no.nav.eessi.pensjon.eux.model.sed.SedType
+import no.nav.eessi.pensjon.eux.model.SedType
+
 import no.nav.eessi.pensjon.json.mapJsonToAny
 import no.nav.eessi.pensjon.json.typeRefs
 import no.nav.eessi.pensjon.models.Behandlingstema

--- a/src/test/kotlin/no/nav/eessi/pensjon/models/SedTypeTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/models/SedTypeTest.kt
@@ -1,11 +1,12 @@
 package no.nav.eessi.pensjon.models
 
-import no.nav.eessi.pensjon.eux.model.sed.SedType
+
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.json.mapJsonToAny
 import no.nav.eessi.pensjon.json.toJson
 import no.nav.eessi.pensjon.json.typeRefs
-import no.nav.eessi.pensjon.models.sed.SedTypeUtils.kanInneholdeIdentEllerFdato
 import no.nav.eessi.pensjon.models.sed.SedTypeUtils.ugyldigeTyper
+import no.nav.eessi.pensjon.models.sed.SedTypeUtils.typerMedIdentEllerFDato
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -50,7 +51,7 @@ internal class SedTypeTest {
     fun `Sjekk antall SED-typer som kan inneholde fnr eller dnr`() {
         assertEquals(
             58,
-            kanInneholdeIdentEllerFdato.size,
+            typerMedIdentEllerFDato.size,
             "Antall SEDer som kan inneholde ident har blitt endret."
         )
     }

--- a/src/test/kotlin/no/nav/eessi/pensjon/oppgaverouting/OppgaveRoutingServiceTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/oppgaverouting/OppgaveRoutingServiceTest.kt
@@ -2,7 +2,8 @@ package no.nav.eessi.pensjon.oppgaverouting
 
 import io.mockk.every
 import io.mockk.mockk
-import no.nav.eessi.pensjon.eux.model.sed.SedType
+import no.nav.eessi.pensjon.eux.model.SedType
+
 import no.nav.eessi.pensjon.json.mapJsonToAny
 import no.nav.eessi.pensjon.json.typeRefs
 import no.nav.eessi.pensjon.klienter.norg2.Norg2ArbeidsfordelingItem

--- a/src/test/kotlin/no/nav/eessi/pensjon/oppgaverouting/Pbuc10Test.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/oppgaverouting/Pbuc10Test.kt
@@ -2,7 +2,8 @@ package no.nav.eessi.pensjon.oppgaverouting
 
 import io.mockk.every
 import io.mockk.mockk
-import no.nav.eessi.pensjon.eux.model.sed.SedType
+import no.nav.eessi.pensjon.eux.model.SedType
+
 import no.nav.eessi.pensjon.models.BucType
 import no.nav.eessi.pensjon.models.Enhet
 import no.nav.eessi.pensjon.models.HendelseType

--- a/src/test/kotlin/no/nav/eessi/pensjon/oppgaverouting/Rbuc02Test.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/oppgaverouting/Rbuc02Test.kt
@@ -2,7 +2,8 @@ package no.nav.eessi.pensjon.oppgaverouting
 
 import io.mockk.every
 import io.mockk.mockk
-import no.nav.eessi.pensjon.eux.model.sed.SedType
+import no.nav.eessi.pensjon.eux.model.SedType
+
 import no.nav.eessi.pensjon.models.BucType
 import no.nav.eessi.pensjon.models.Enhet
 import no.nav.eessi.pensjon.models.HendelseType

--- a/src/test/kotlin/no/nav/eessi/pensjon/pdf/PDFServiceTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/pdf/PDFServiceTest.kt
@@ -6,10 +6,11 @@ import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import no.nav.eessi.pensjon.buc.EuxDokumentHelper
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.eux.model.document.MimeType
 import no.nav.eessi.pensjon.eux.model.document.SedDokumentfiler
 import no.nav.eessi.pensjon.eux.model.document.SedVedlegg
-import no.nav.eessi.pensjon.eux.model.sed.SedType
+
 import no.nav.eessi.pensjon.json.mapJsonToAny
 import no.nav.eessi.pensjon.json.typeRefs
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/src/test/kotlin/no/nav/eessi/pensjon/personidentifisering/PersonidentifiseringServiceTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/personidentifisering/PersonidentifiseringServiceTest.kt
@@ -3,6 +3,7 @@ package no.nav.eessi.pensjon.personidentifisering
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.eux.model.sed.Bruker
 import no.nav.eessi.pensjon.eux.model.sed.Brukere
 import no.nav.eessi.pensjon.eux.model.sed.Krav
@@ -19,7 +20,7 @@ import no.nav.eessi.pensjon.eux.model.sed.RNav
 import no.nav.eessi.pensjon.eux.model.sed.RelasjonAvdodItem
 import no.nav.eessi.pensjon.eux.model.sed.RelasjonTilAvdod
 import no.nav.eessi.pensjon.eux.model.sed.SED
-import no.nav.eessi.pensjon.eux.model.sed.SedType
+
 import no.nav.eessi.pensjon.eux.model.sed.Status
 import no.nav.eessi.pensjon.eux.model.sed.TilbakekrevingBrukere
 import no.nav.eessi.pensjon.json.mapJsonToAny

--- a/src/test/kotlin/no/nav/eessi/pensjon/personidentifisering/helpers/SedFnrSokTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/personidentifisering/helpers/SedFnrSokTest.kt
@@ -1,5 +1,6 @@
 package no.nav.eessi.pensjon.personidentifisering.helpers
 
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.eux.model.sed.Bruker
 import no.nav.eessi.pensjon.eux.model.sed.Kontekst
 import no.nav.eessi.pensjon.eux.model.sed.Nav
@@ -8,7 +9,7 @@ import no.nav.eessi.pensjon.eux.model.sed.Person
 import no.nav.eessi.pensjon.eux.model.sed.PinItem
 import no.nav.eessi.pensjon.eux.model.sed.PinLandItem
 import no.nav.eessi.pensjon.eux.model.sed.SED
-import no.nav.eessi.pensjon.eux.model.sed.SedType
+
 import no.nav.eessi.pensjon.eux.model.sed.X005
 import no.nav.eessi.pensjon.eux.model.sed.XNav
 import no.nav.eessi.pensjon.json.mapJsonToAny

--- a/src/test/kotlin/no/nav/eessi/pensjon/personidentifisering/relasjoner/RelasjonTestBase.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/personidentifisering/relasjoner/RelasjonTestBase.kt
@@ -1,5 +1,6 @@
 package no.nav.eessi.pensjon.personidentifisering.relasjoner
 
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.eux.model.sed.Bruker
 import no.nav.eessi.pensjon.eux.model.sed.Brukere
 import no.nav.eessi.pensjon.eux.model.sed.Krav
@@ -14,7 +15,7 @@ import no.nav.eessi.pensjon.eux.model.sed.RNav
 import no.nav.eessi.pensjon.eux.model.sed.RelasjonAvdodItem
 import no.nav.eessi.pensjon.eux.model.sed.RelasjonTilAvdod
 import no.nav.eessi.pensjon.eux.model.sed.SED
-import no.nav.eessi.pensjon.eux.model.sed.SedType
+
 import no.nav.eessi.pensjon.eux.model.sed.Status
 import no.nav.eessi.pensjon.eux.model.sed.TilbakekrevingBrukere
 import no.nav.eessi.pensjon.personidentifisering.helpers.Rolle

--- a/src/test/kotlin/no/nav/eessi/pensjon/personidentifisering/relasjoner/RelasjonsHandlerTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/personidentifisering/relasjoner/RelasjonsHandlerTest.kt
@@ -1,5 +1,6 @@
 package no.nav.eessi.pensjon.personidentifisering.relasjoner
 
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.eux.model.sed.KravType
 import no.nav.eessi.pensjon.eux.model.sed.P15000
 import no.nav.eessi.pensjon.eux.model.sed.P2000
@@ -8,7 +9,7 @@ import no.nav.eessi.pensjon.eux.model.sed.P5000
 import no.nav.eessi.pensjon.eux.model.sed.P8000
 import no.nav.eessi.pensjon.eux.model.sed.RelasjonTilAvdod
 import no.nav.eessi.pensjon.eux.model.sed.SED
-import no.nav.eessi.pensjon.eux.model.sed.SedType
+
 import no.nav.eessi.pensjon.json.mapJsonToAny
 import no.nav.eessi.pensjon.json.typeRefs
 import no.nav.eessi.pensjon.models.BucType

--- a/src/test/kotlin/no/nav/eessi/pensjon/sed/SedHendelseTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/sed/SedHendelseTest.kt
@@ -1,7 +1,8 @@
 package no.nav.eessi.pensjon.sed
 
+import no.nav.eessi.pensjon.eux.model.SedType
 import no.nav.eessi.pensjon.models.BucType
-import no.nav.eessi.pensjon.eux.model.sed.SedType
+
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 


### PR DESCRIPTION
1. Bumper alt av versjoner
2. En del enkle endringer som feks. ny sedtype fra eux rettes til  no.nav.eessi.pensjon.eux.model.sed.SedType, no.nav.eessi.pensjon.eux.model.SedType
3. Gradle bumpet til 6.8.2, 7.3.2